### PR TITLE
Fix plot ownership being displayed when disabled

### DIFF
--- a/A Plot for Life/v2.33 & Snap Pro v1.4.1/Custom/A_Plot_for_Life/Compile/fn_selfActions.sqf
+++ b/A Plot for Life/v2.33 & Snap Pro v1.4.1/Custom/A_Plot_for_Life/Compile/fn_selfActions.sqf
@@ -230,7 +230,8 @@ if (!isNull cursorTarget && !_inVehicle && !_isPZombie && (player distance curso
 			};
 		};
 		if (s_player_plot_take_ownership < 0) then {
-			if (DZE_APlotforLife) then {
+			// NK: Make sure we only allow taking ownership if both DZE_APlotforLife and DZE_PlotOwnership is true
+			if (DZE_APlotforLife && DZE_PlotOwnership) then {
 				_isowner = [player, _cursorTarget] call FNC_check_owner;
 				If (( _isowner select 0 )) then{
 					s_player_plot_take_ownership = player addAction ["Take plot items ownership", "Custom\A_Plot_for_Life\Action\plot_take_ownership.sqf", "", 1, false];


### PR DESCRIPTION
Currently the code does not check that DZE_PlotOwnership is true, this means that it is displayed as an option regardless of being disabled.

We should check both DZE_APlotforLife and DZE_PlotOwnership are true.

SignedOff-By: Nigel Kukard nkukard@lbsd.net
